### PR TITLE
Add repo pull before running script.

### DIFF
--- a/bash/README.md
+++ b/bash/README.md
@@ -55,6 +55,8 @@ export SCHEDD_NAME=shared_volume_schedd_1
 export SE_NAME=shared_volume_JCentral-dev-SE_1
 export WORKER_NAME=shared_volume_worker1_1
 ```
+#### 2.3 Make sure that docker is in the user group in the running environment.
+If not please follow this [Article](https://docs.docker.com/engine/install/linux-postinstall/) to add the user to the docker group 
 
 ### 3. Running the Setup
 

--- a/bash/tasks/create_jar.sh
+++ b/bash/tasks/create_jar.sh
@@ -4,6 +4,30 @@ set -e
 
 source "$1"
 
+pull_new_changes() {
+    local dir_name="$1"
+    cd "$dir_name" || return
+
+    # Fetch changes from all remote branches
+    git fetch --all
+
+    # Check if there are any changes to be pulled
+    if [ $(git rev-list HEAD...@{u} --count) -gt 0 ]; then
+
+        # Changes exist, ask the user if they want to pull
+        read -p "There are new changes in $1. Do you want to pull them? (y/n): " response
+        if [[ $response =~ ^[Yy]$ ]]; then
+            git pull --all
+        else
+            echo "Changes not pulled."
+        fi
+    else
+        echo "No new changes to pull."
+    fi
+}
+
+pull_new_changes $JALIEN
+
 chmod +x "$JALIEN/compile.sh"
 "$JALIEN/compile.sh" cs
 echo "alien-cs.jar created"

--- a/bash/tasks/create_jar.sh
+++ b/bash/tasks/create_jar.sh
@@ -14,8 +14,12 @@ pull_new_changes() {
     # Check if there are any changes to be pulled
     if [ $(git rev-list HEAD...@{u} --count) -gt 0 ]; then
     
-        # Pull changes from all remote branches.
-        git pull --all
+        # Attempt to pull changes from all remote branches
+        if git pull --all; then
+            echo "Changes pulled successfully."
+        else
+            echo "Failed to pull changes. Resolving conflicts..."
+        fi
       
     else
         echo "No new changes to pull."

--- a/bash/tasks/create_jar.sh
+++ b/bash/tasks/create_jar.sh
@@ -13,14 +13,10 @@ pull_new_changes() {
 
     # Check if there are any changes to be pulled
     if [ $(git rev-list HEAD...@{u} --count) -gt 0 ]; then
-
-        # Changes exist, ask the user if they want to pull
-        read -p "There are new changes in $1. Do you want to pull them? (y/n): " response
-        if [[ $response =~ ^[Yy]$ ]]; then
-            git pull --all
-        else
-            echo "Changes not pulled."
-        fi
+    
+        # Pull changes from all remote branches.
+        git pull --all
+      
     else
         echo "No new changes to pull."
     fi

--- a/bash/tasks/create_shared.sh
+++ b/bash/tasks/create_shared.sh
@@ -13,7 +13,7 @@ execute() {
 
 # Remove the shared volume if it exists
 if [ -d "$SHARED_VOLUME" ]; then
-    rm -rf "$SHARED_VOLUME"
+    sudo rm -rf "$SHARED_VOLUME"
     echo "Directory $SHARED_VOLUME has been removed."
 fi
 

--- a/bash/tasks/start_opt.sh
+++ b/bash/tasks/start_opt.sh
@@ -1,5 +1,3 @@
 #!/bin/bash
 
-source ../config/config.sh
-
 "$SHARED_VOLUME"/optimiser.sh 


### PR DESCRIPTION
Fix #32 

- The pulling will not succeed once we have conflicts with the local repo. But a message will display indicating that and then the user can sync the repo manually by rebasing or merging the local changes. Still the jar file will be created.
- Update the readme.